### PR TITLE
adding chmod command to Dockerfile to make entrypoint.sh executable

### DIFF
--- a/servers/wordpress/Dockerfile
+++ b/servers/wordpress/Dockerfile
@@ -39,6 +39,7 @@ RUN git clone https://github.com/roots/bedrock /usr/src/bedrock \
 
 #Copy entry point and php config
 COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod 777 /entrypoint.sh
 COPY php.ini /usr/local/etc/php/php.ini
 
 # Fix apache


### PR DESCRIPTION
Related issue:
http://stackoverflow.com/questions/35351834/container-command-could-not-be-invoked
